### PR TITLE
fix(import): skip attributes that are not needed for a specific product type

### DIFF
--- a/src/coffee/product-type-generator.coffee
+++ b/src/coffee/product-type-generator.coffee
@@ -215,8 +215,9 @@ class ProductTypeGenerator
 
         if _.isString(value) and value.length > 0
           if attributeDefinitions[header]
+            unless value.toLowerCase() is 'x'
+              continue
             attributeDefinition = attributeDefinitions[header]
-            attributeDefinition.name = value unless value.toLowerCase() is 'x'
             productTypeDefinition.attributes.push attributeDefinition
           else
             console.log "[WARN] No attribute definition found with name '#{header}', skipping..."


### PR DESCRIPTION
The problem is that some attributes get names like "2" or "3". I still don't really understand what happens here, but this apparently fixes it. 

cc @hajoeichler @emmenko 