### PR TITLE
Use referenceTypeId when it is available

### DIFF
--- a/src/coffee/product-type-generator.coffee
+++ b/src/coffee/product-type-generator.coffee
@@ -107,7 +107,9 @@ class ProductTypeGenerator
           label: @_i18n row, "#{ATTRIBUTE_TYPES.enum}Label"
         ]
       when ATTRIBUTE_TYPES.reference
-        if row['type']
+        if row['type.referenceTypeId']
+          type['referenceTypeId'] = row['type.referenceTypeId']
+        else if row['type']
           type['referenceTypeId'] = @_type(@_typeOrElementType(rawTypeName))
       when ATTRIBUTE_TYPES.set
         # TODO: ensure set is correctly build


### PR DESCRIPTION
This will try to take type.referenceTypeId from CSV import when it is available.. it fixes an error when importing incorrect referenceTypeId: "reference" instead of ids provided in the import file