### PR TITLE
chore(package.json): revert dependency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "csv": "^1.1.1",
-    "exceljs": "^0.4.10",
+    "exceljs": "0.3.0",
     "iconv-lite": "^0.4.17",
     "jszip": "^3.1.3",
     "optimist": "^0.6.0",


### PR DESCRIPTION
revert `exceljs` dependency from 0.4.10 to 0.3.0 for node v4 compatibility
