### PR TITLE
chore: Drop support for Node < 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: node_js
 node_js:
-  - '6'
-  - '8'
+  - '10'
+  - '12'
 before_script:
 - npm install -g grunt-cli
 - gem install cucumber aruba
 - ./create_config.sh
 script:
 - npm test
-- cucumber -t ~@wip
+- cucumber --tags "not @wip"
 - mkdir -p tmp && ./bin/product-type-generator --types data/sample-product-types.csv
   --attributes data/sample-product-types-attributes.csv --target ./tmp --zip
 - mkdir -p tmp && ./bin/product-type-generator --types data/marketplace-types.csv

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "main": "main.js",
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 8.0.0"
   },
   "scripts": {
     "test": "grunt coverage",


### PR DESCRIPTION
#### Drop Support for node less than version 8
1) Updated Node JS version on package.json
2) Updated Test cases node JS version

Closes #75 